### PR TITLE
Add subcommands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             --skip invalid/unicode_delete.kdl
           )
 
-          target/release/kdl-test "${flags[@]}"
+          target/release/kdl-test run "${flags[@]}"
       -
         name: Create archive
         run: |

--- a/src/kdl_test.rs
+++ b/src/kdl_test.rs
@@ -1,2 +1,3 @@
 pub mod decoder_exe;
 pub mod test_cases;
+pub mod test_files;

--- a/src/kdl_test/test_files.rs
+++ b/src/kdl_test/test_files.rs
@@ -1,0 +1,17 @@
+use std::borrow::Cow;
+
+use rust_embed::{Embed, EmbeddedFile};
+
+#[derive(Embed)]
+#[folder = "test_cases/"]
+pub struct TestFiles;
+
+impl TestFiles {
+    pub fn iter_files() -> impl Iterator<Item = (Cow<'static, str>, EmbeddedFile)> {
+        TestFiles::iter().map(|filepath| {
+            let file = TestFiles::get(&filepath)
+                .unwrap_or_else(|| panic!("Test file unexpectedly does not exist: {}", filepath));
+            (filepath, file)
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 mod kdl_test;
-use colored::Colorize;
-use kdl_test::decoder_exe::DecoderExe;
-use kdl_test::test_cases::TestCase;
+
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use colored::Colorize;
+
+use crate::kdl_test::decoder_exe::DecoderExe;
+use crate::kdl_test::test_cases::TestCase;
 
 #[derive(Parser, Debug)]
 #[command(name = "kdl-test")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod kdl_test;
 
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 
@@ -27,6 +27,9 @@ enum Command {
 
     /// Extract all test files to a directory
     Extract(ExtractArgs),
+
+    /// Get the input of the given test
+    Get(GetArgs),
 }
 
 fn main() -> Result<()> {
@@ -34,6 +37,7 @@ fn main() -> Result<()> {
     match args.command {
         Command::Run(args) => run_tests(args),
         Command::Extract(args) => extract_tests(args),
+        Command::Get(args) => get_test_input(args),
     }
 }
 
@@ -138,5 +142,21 @@ fn extract_tests(args: ExtractArgs) -> Result<()> {
             .with_context(|| format!("Failed to create file: {}", dest_path.display()))?;
         dest.write_all(&file.data)?;
     }
+    Ok(())
+}
+
+/***** Get test input *****/
+
+#[derive(Parser, Debug)]
+struct GetArgs {
+    /// Test to get.
+    /// e.g. valid/arg_bare.kdl
+    test: String,
+}
+
+fn get_test_input(args: GetArgs) -> Result<()> {
+    let file =
+        TestFiles::get(&args.test).ok_or_else(|| anyhow!("Test does not exist: {}", args.test))?;
+    io::stdout().write_all(&file.data)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,34 @@ use kdl_test::decoder_exe::DecoderExe;
 use kdl_test::test_cases::TestCase;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(name = "kdl-test")]
 #[command(about = "An implementation-agnostic test suite for KDL", long_about = None)]
 struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Run tests
+    Run(RunArgs),
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    match args.command {
+        Command::Run(args) => run_tests(args),
+    }
+}
+
+/***** Run tests *****/
+
+#[derive(Parser, Debug)]
+struct RunArgs {
     /// Path to decoder executable
     #[arg(long, value_parser = validate_executable)]
     decoder: PathBuf,
@@ -29,8 +50,7 @@ fn validate_executable(s: &str) -> Result<PathBuf> {
     which::which(s).with_context(|| format!("Could not find executable '{}'", s))
 }
 
-fn main() -> Result<()> {
-    let args = Args::parse();
+fn run_tests(args: RunArgs) -> Result<()> {
     let decoder = DecoderExe::new(args.decoder);
 
     let (valid_tests, invalid_tests) = kdl_test::test_cases::load()?;


### PR DESCRIPTION
Change running tests to `kdl-test run ...`, add `extract` and `get` modes